### PR TITLE
Fixed like and check if type is a object

### DIFF
--- a/src/Auth/Models/Sessions.php
+++ b/src/Auth/Models/Sessions.php
@@ -28,7 +28,6 @@ class Sessions extends Model
     public function initialize()
     {
         $this->belongsTo('users_id', 'Baka\Auth\Models\Users', 'id', ['alias' => 'user']);
-        $this->hasMany('id', 'Baka\Auth\Models\Users', 'sessions_id', ['alias' => 'sessionKeys']);
     }
 
     /**

--- a/src/Contracts/Elasticsearch/ElasticIndexModelTrait.php
+++ b/src/Contracts/Elasticsearch/ElasticIndexModelTrait.php
@@ -12,8 +12,6 @@ use Phalcon\Mvc\Model\Query\Builder;
 
 trait ElasticIndexModelTrait
 {
-    protected int $elasticMaxDepth = 3;
-
     /**
      * Fields we want to have excluded from the audits.
      *
@@ -29,7 +27,7 @@ trait ElasticIndexModelTrait
      * With this variable we tell elasticsearch to not analyze string fields in order to allow us
      * to perform wildcard matches.
      *
-     * @var boolean
+     * @var bool
      */
     public bool $elasticSearchNotAnalyzed = true;
 
@@ -43,7 +41,7 @@ trait ElasticIndexModelTrait
     public function saveToElastic(int $maxDepth = 0) : array
     {
         if ($maxDepth === 0) {
-            $maxDepth = $this->elasticMaxDepth;
+            $maxDepth = isset($this->elasticMaxDepth) ? $this->elasticMaxDepth : 3;
         }
 
         //insert into elastic

--- a/src/Contracts/Http/Api/CrudElasticBehaviorTrait.php
+++ b/src/Contracts/Http/Api/CrudElasticBehaviorTrait.php
@@ -54,11 +54,7 @@ trait CrudElasticBehaviorTrait
     protected function getRecords(array $processedRequest) : array
     {
         $results = Documents::findBySqlPaginated($processedRequest['sql']->getParsedQuery(), $this->model);
-
-        return [
-            'results' => $results['results'],
-            'total' => $results['total']
-        ];
+        return $results['results'];
     }
 
     /**

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -3,15 +3,15 @@
 namespace Baka\Database;
 
 use Baka\Contracts\Database\ModelInterface;
-use Phalcon\Mvc\ModelInterface as PhalconModelInterface;
 use Baka\Database\Exception\ModelNotFoundException;
 use Baka\Database\Exception\ModelNotProcessedException;
 use function Baka\getShortClassName;
 use Phalcon\Mvc\Model as PhalconModel;
 use Phalcon\Mvc\Model\ResultsetInterface;
+use Phalcon\Mvc\ModelInterface as PhalconModelInterface;
 use RuntimeException;
 
-class Model extends PhalconModel implements ModelInterface , PhalconModelInterface
+class Model extends PhalconModel implements ModelInterface, PhalconModelInterface
 {
     /**
      * Define a model alias to throw exception msg to the end user.
@@ -319,5 +319,20 @@ class Model extends PhalconModel implements ModelInterface , PhalconModelInterfa
         throw new ModelNotProcessedException(
             getShortClassName(new static) . ' ' . current($this->getMessages())->getMessage()
         );
+    }
+
+    /**
+     * hasProperty.
+     *
+     * @param  string $property
+     *
+     * @return bool
+     */
+    public function hasProperty(string $property) : bool
+    {
+        $model = self::findFirstOrFail();
+        $metadata = $model->getModelsMetaData();
+        $attributes = $metadata->getAttributes($model);
+        return key_exists($property, $attributes);
     }
 }

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -330,9 +330,8 @@ class Model extends PhalconModel implements ModelInterface, PhalconModelInterfac
      */
     public function hasProperty(string $property) : bool
     {
-        $model = self::findFirstOrFail();
-        $metadata = $model->getModelsMetaData();
-        $attributes = $metadata->getAttributes($model);
+        $metadata = $this->getModelsMetaData();
+        $attributes = $metadata->getAttributes($this);
         return key_exists($property, $attributes);
     }
 }

--- a/src/Elasticsearch/IndexBuilder.php
+++ b/src/Elasticsearch/IndexBuilder.php
@@ -237,8 +237,8 @@ class IndexBuilder
                     $alias = 'get' . $has->getOptions()['alias'];
                     $aliasRecords = $data->$alias('is_deleted = 0');
 
-                    if ($aliasRecords) {
-                        $document[$aliasKey] = $aliasRecords->toFullArray();
+                    if ($aliasRecords && is_object($aliasRecords)) {
+                        $document[$aliasKey] = $aliasRecords->toArray();
                         //$document[$aliasKey] = ModelCustomFields::getCustomFields($aliasRecords, true);
 
                         if ($depth < $maxDepth) {
@@ -270,9 +270,9 @@ class IndexBuilder
                     $alias = 'get' . $has->getOptions()['alias'];
                     $aliasRecords = $data->$alias('is_deleted = 0');
 
-                    if (count($aliasRecords) > 0) {
+                    if (count($aliasRecords) > 0 && is_object($aliasRecords)) {
                         foreach ($aliasRecords as $k => $relation) {
-                            $document[$aliasKey][$k] = $relation->toFullArray();
+                            $document[$aliasKey][$k] = $relation->toArray();
                             //$document[$aliasKey][$k] = $relation::getCustomFields($relation, true);
 
                             if ($depth < $maxDepth) {

--- a/src/Elasticsearch/IndexBuilder.php
+++ b/src/Elasticsearch/IndexBuilder.php
@@ -235,10 +235,12 @@ class IndexBuilder
                 if ($data->$alias) {
                     //if alias exist over write it and get the none deleted
                     $alias = 'get' . $has->getOptions()['alias'];
-                    $aliasRecords = $data->$alias('is_deleted = 0');
-
+                    $aliasRecords = $data->$alias();
+                    if (is_object($aliasRecords) && $aliasRecords->hasProperty('is_deleted')) {
+                        $aliasRecords = $data->$alias('is_deleted = 0');
+                    }
                     if ($aliasRecords && is_object($aliasRecords)) {
-                        $document[$aliasKey] = $aliasRecords->toArray();
+                        $document[$aliasKey] = $aliasRecords->toFullArray();
                         //$document[$aliasKey] = ModelCustomFields::getCustomFields($aliasRecords, true);
 
                         if ($depth < $maxDepth) {
@@ -268,11 +270,15 @@ class IndexBuilder
                 if ($data->$alias->count()) {
                     //if alias exist over write it and get the none deleted
                     $alias = 'get' . $has->getOptions()['alias'];
-                    $aliasRecords = $data->$alias('is_deleted = 0');
-
-                    if (count($aliasRecords) > 0 && is_object($aliasRecords)) {
+                    $metadata = $data->$alias()[0];
+                    $aliasIsDeleted = null;
+                    if ($metadata->hasProperty('is_deleted')) {
+                        $aliasIsDeleted = 'is_deleted = 0';
+                    }
+                    $aliasRecords = $data->$alias($aliasIsDeleted);
+                    if (count($aliasRecords) > 0) {
                         foreach ($aliasRecords as $k => $relation) {
-                            $document[$aliasKey][$k] = $relation->toArray();
+                            $document[$aliasKey][$k] = $relation->toFullArray();
                             //$document[$aliasKey][$k] = $relation::getCustomFields($relation, true);
 
                             if ($depth < $maxDepth) {

--- a/src/Http/QueryParser/QueryParser.php
+++ b/src/Http/QueryParser/QueryParser.php
@@ -470,7 +470,7 @@ class QueryParser
     protected static function containsWildcards(string $string) : bool
     {
         foreach (self::WILDCARDS as $wildcard) {
-            if (Str::contains($wildcard, $string)) {
+            if (Str::contains($string, $wildcard)) {
                 return true;
             }
         }


### PR DESCRIPTION
On my test sometime the $aliasRecords is a string for this reason i check if it is a object, change toFullArray to toArray.
And in Str::contains the [example](https://github.com/bakaphp/support#contains) learned that first params is full array and second params is a search word