### PR TITLE
[0.6] Create beforeSoftDelete method

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -110,7 +110,7 @@ class Model extends PhalconModel implements ModelInterface, PhalconModelInterfac
     public function beforeSoftDelete()
     {
     }
-    
+
     /**
      * Get by Id or thrown an exception.
      *

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -95,11 +95,21 @@ class Model extends PhalconModel implements ModelInterface, PhalconModelInterfac
      */
     public function softDelete()
     {
+        $this->beforeSoftDelete();
+
         $this->is_deleted = 1;
 
         return $this->save();
     }
 
+    /**
+     * Execute actions before the softDelete method.
+     *
+     * @return void
+     */
+    public function beforeSoftDelete()
+    {
+    }
     /**
      * Get by Id or thrown an exception.
      *

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -110,6 +110,7 @@ class Model extends PhalconModel implements ModelInterface, PhalconModelInterfac
     public function beforeSoftDelete()
     {
     }
+    
     /**
      * Get by Id or thrown an exception.
      *


### PR DESCRIPTION
### Overview
We need a method that execute actions before the softDelete, with expectation of be overwrite when its need to.

### Resolve
Create an method called beforeSoftDelete that execute actions before the SoftDelete.
Calls the method beforeSoftDelete at the start of the softDelete method.