### PR TITLE
[0.7] Hotfix Queue Workers

### DIFF
--- a/src/Queue/Queue.php
+++ b/src/Queue/Queue.php
@@ -82,6 +82,13 @@ class Queue
 
             $channel->queue_declare($queueName, false, true, false, false);
 
+            //Fair dispatch https://lukasmestan.com/rabbitmq-broken-pipe-or-closed-connection/
+            $prefetchSize = null;    // message size in bytes or null, otherwise error
+            $prefetchCount = 1;      // prefetch count value
+            $applyPerChannel = null; // can be false or null, otherwise error
+
+            $channel->basic_qos($prefetchSize, $prefetchCount, $applyPerChannel);
+
             /*
                 queueName: Queue from where to get the messages
                 consumer_tag: Consumer identifier


### PR DESCRIPTION
When working with large data on the queue we get this issue with rabbitmq

```
Uncaught PhpAmqpLib\Exception\AMQPConnectionClosedException: 
Broken pipe or closed connection in 
/app/vendor/php-amqplib/php-amqplib/PhpAmqpLib/Wire/IO/StreamIO.php:172`
```

With this pull request we apply fair dispatch, to limit the # of message a worker can get at the same time