### PR TITLE
[0.7] Hotfix Elastic Total Records

### DIFF
--- a/src/Elasticsearch/Query.php
+++ b/src/Elasticsearch/Query.php
@@ -16,6 +16,7 @@ class Query
 {
     public ?ElasticModelInterface $model = null;
     protected string $sql;
+    protected int $totalResultSet = 0;
     protected int $total = 0;
 
     /**
@@ -85,9 +86,10 @@ class Query
 
         //set total
         $dataset = isset($results['datarows']) ? $results['datarows'] : $results['hits']['hits'];
-        $this->total = count($dataset);
+        $this->totalResultSet = count($dataset);
+        $this->total = $results['hits']['total']['value'];
 
-        if (!$this->total) {
+        if (!$this->totalResultSet) {
             return [];
         }
 
@@ -142,7 +144,7 @@ class Query
      */
     private function getResultSet(array $elasticResults) : SplFixedArray
     {
-        $results = new SplFixedArray($this->total);
+        $results = new SplFixedArray($this->totalResultSet);
         $i = 0;
 
         if (!empty($elasticResults)) {


### PR DESCRIPTION
Fix Elasticsearch total search records.  Elastic provides a total of all the records of the search without limit thus allowing us to make simple pagination.