### PR TITLE
[0.3] Improve Elastic Additional Params

### DIFF
--- a/src/Http/QueryParser/NestedParenthesesParser.php
+++ b/src/Http/QueryParser/NestedParenthesesParser.php
@@ -169,6 +169,10 @@ class NestedParenthesesParser
          *  2 -> value
          *  3 -> join operator.
          */
+
+        /**
+         * @todo move the index to constants same for additional params in controller
+         */
         foreach ($additionalQueryFields as $query) {
             $newAdditionalQueryFields[$query[0]] = [
                 'comparison' => implode('', array_slice($query, 0, 3)),

--- a/src/Http/QueryParser/NestedParenthesesParser.php
+++ b/src/Http/QueryParser/NestedParenthesesParser.php
@@ -161,10 +161,18 @@ class NestedParenthesesParser
     {
         $newAdditionalQueryFields = [];
 
+        /**
+         * Additional Params
+         * ['follows_rs.users_id', ':', $this->userData->getId()],
+         *  0 -> key
+         *  1 -> operation
+         *  2 -> value
+         *  3 -> join operator.
+         */
         foreach ($additionalQueryFields as $query) {
             $newAdditionalQueryFields[$query[0]] = [
-                'comparison' => implode('', $query),
-                'joiner' => ',',
+                'comparison' => implode('', array_slice($query, 0, 3)),
+                'joiner' => !is_null($query[3]) && QueryParser::isAValidJoiner($query[3]) ? $query[3] : ',',
                 'key' => $query[0]
             ];
         }

--- a/src/Http/QueryParser/NestedParenthesesParser.php
+++ b/src/Http/QueryParser/NestedParenthesesParser.php
@@ -172,7 +172,7 @@ class NestedParenthesesParser
         foreach ($additionalQueryFields as $query) {
             $newAdditionalQueryFields[$query[0]] = [
                 'comparison' => implode('', array_slice($query, 0, 3)),
-                'joiner' => !is_null($query[3]) && QueryParser::isAValidJoiner($query[3]) ? $query[3] : ',',
+                'joiner' => isset($query[3]) && QueryParser::isAValidJoiner($query[3]) ? $query[3] : ',',
                 'key' => $query[0]
             ];
         }

--- a/tests/integration/Http/QueryParserTest.php
+++ b/tests/integration/Http/QueryParserTest.php
@@ -120,6 +120,32 @@ class QueryParserTest extends PhalconUnitTestCase
         }
     }
 
+    public function testSimpleQueryWithConditionalAndAdditionalQueryWithOrFields()
+    {
+        $limit = 100;
+        $params = [];
+        $params['q'] = '(is_deleted:0,user.displayname:mc%,user.id>0;user.user_level:3)';
+        //$params['fields'] = '';
+        $params['limit'] = $limit;
+        $params['page'] = '1';
+        $params['sort'] = 'id|desc';
+
+        $queryParser = new QueryParser(new Leads(), $params);
+        $queryParser->setAdditionalQueryFields([
+            ['is_deleted', ':', '0', ';'],
+            ['companies_id', ':', 1],
+        ]);
+
+        $results = ElasticDocuments::findBySql($queryParser->getParsedQuery());
+
+        foreach ($results as $result) {
+            $this->assertTrue(isset($result['id']));
+            if (isset($result['user'])) {
+                $this->assertTrue(isset($result['user']['id']));
+            }
+        }
+    }
+
     public function testSimpleQueryWithModel()
     {
         $limit = 100;


### PR DESCRIPTION
- Improve additional params in elastic by allowing the user to specify OR or break a AND, passing a thrid params to additional params


```
['is_deleted', ':', 0, ''],
['companies_id', ':', 95, ';'],
['people_rs.id', '>', 0],
```

``` SQL
"
SELECT * 
FROM leads as l, l.people as people_rs  
	WHERE 
		((1 = 1) ) AND ( (is_deleted = 0) ) 
		AND ( (companies_id = 95) OR (people_rs.id >= 0)) 

	ORDER BY id DESC  LIMIT 0,  25"
```