### PR TITLE
feat : Model extended query builder

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -8,14 +8,12 @@ use Baka\Contracts\Database\ModelInterface;
 use Baka\Database\Exception\ModelNotFoundException;
 use Baka\Database\Exception\ModelNotProcessedException;
 use function Baka\getShortClassName;
-
 use Phalcon\Di;
 use Phalcon\Mvc\Model as PhalconModel;
 use Phalcon\Mvc\Model\Query\BuilderInterface;
 use Phalcon\Mvc\Model\Relation;
 use Phalcon\Mvc\Model\Resultset\Simple;
 use Phalcon\Mvc\Model\ResultsetInterface;
-
 use Phalcon\Mvc\ModelInterface as PhalconModelInterface;
 use RuntimeException;
 

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -8,7 +8,10 @@ use Baka\Contracts\Database\ModelInterface;
 use Baka\Database\Exception\ModelNotFoundException;
 use Baka\Database\Exception\ModelNotProcessedException;
 use function Baka\getShortClassName;
+
+use Phalcon\Di;
 use Phalcon\Mvc\Model as PhalconModel;
+use Phalcon\Mvc\Model\Query\BuilderInterface;
 use Phalcon\Mvc\Model\Relation;
 use Phalcon\Mvc\Model\Resultset\Simple;
 use Phalcon\Mvc\Model\ResultsetInterface;
@@ -579,5 +582,16 @@ class Model extends PhalconModel implements ModelInterface, PhalconModelInterfac
                 $params
             )
         );
+    }
+
+    /**
+     * Return a query builder for the current model.
+     * So we can do more complicated queries.
+     *
+     * @return BuilderInterface
+     */
+    public static function queryBuilder() : BuilderInterface
+    {
+        return Di::getDefault()->get('modelsManager')->createBuilder();
     }
 }

--- a/tests/integration/Database/ModelTest.php
+++ b/tests/integration/Database/ModelTest.php
@@ -152,4 +152,32 @@ class ModelTest extends PhalconUnitTestCase
         $this->assertIsObject($leads);
         $this->assertTrue($leads->count() > 0);
     }
+
+    public function testQueryBuilderByGettingFirst()
+    {
+        $leads = Leads::queryBuilder()
+            ->addFrom(Leads::class)
+            ->where('id > :id:', ['id' => 0])
+            ->getQuery()
+            ->execute()
+            ->getFirst();
+
+        $this->assertIsObject($leads);
+        $this->assertTrue($leads instanceof Leads);
+    }
+
+    public function testQueryBuilderByGettingAll()
+    {
+        $leads = Leads::queryBuilder()
+            ->addFrom(Leads::class)
+            ->where('id > :id:', ['id' => 0])
+            ->limit(10)
+            ->getQuery()
+            ->execute();
+
+        $this->assertGreaterThan(0, $leads->count());
+        foreach ($leads as $lead) {
+            $this->assertTrue($lead instanceof Leads);
+        }
+    }
 }


### PR DESCRIPTION
- Extender query builder, allowing the uesr to write complex queries directly from any model

```
$query = Model::queryBuilder();

$query->addFrom(Peoples::class, 'p')
            ->join(
                Contacts::class,
                'p.id = c.peoples_id',
                'c'
            )
            ->where('c.value = :value:', ['value' => $email])
            ->andWhere('p.companies_id = :companies_id:', ['companies_id' => $company->getId()])
            ->getQuery()
            ->execute()
            ->getFirst()
```