### PR TITLE
feat : session not found exception

### DIFF
--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -15,7 +15,7 @@ class HttpException extends Exception
     /**
      * Get the http status code of the exception.
      *
-     * @return string
+     * @return int
      */
     public function getHttpCode() : int
     {

--- a/src/Http/Exception/SessionNotFound.php
+++ b/src/Http/Exception/SessionNotFound.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baka\Http\Exception;
+
+use Baka\Exception\HttpException;
+use Baka\Http\Response\Phalcon as Response;
+
+class SessionNotFound extends HttpException
+{
+    /**
+     * Code 499 , is a specific http code for kanvas frontend,
+     * when they see this error they will know they have to clear user session on device.
+     */
+    protected int $httpCode = Response::SESSION_NOT_FOUND;
+    protected string $httpMessage = 'Unauthorized';
+    protected string $severity = 'warning';
+}

--- a/src/Http/Response/Phalcon.php
+++ b/src/Http/Response/Phalcon.php
@@ -9,7 +9,6 @@ use Baka\Http\Exception\InternalServerErrorException;
 use Baka\Http\Request\Phalcon as Request;
 use Error;
 use Phalcon\Http\Response;
-
 use Throwable;
 
 class Phalcon extends Response
@@ -26,6 +25,7 @@ class Phalcon extends Response
     const FORBIDDEN = 403;
     const NOT_FOUND = 404;
     const NOT_ACCEPTABLE = 406;
+    const SESSION_NOT_FOUND = 499;
     const INTERNAL_SERVER_ERROR = 500;
     const NOT_IMPLEMENTED = 501;
     const BAD_GATEWAY = 502;
@@ -42,6 +42,7 @@ class Phalcon extends Response
         403 => 'Forbidden',
         404 => 'Not Found',
         422 => 'Unprocessable Entity',
+        499 => 'Session Not Found',
         500 => 'Internal Server Error',
         501 => 'Not Implemented',
         502 => 'Bad Gateway',

--- a/tests/unit/Http/Request/ExceptionTest.php
+++ b/tests/unit/Http/Request/ExceptionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baka\Test\Unit\Http\Request;
+
+use Baka\Http\Exception\BadRequestException;
+use Baka\Http\Exception\ForbiddenException;
+use Baka\Http\Exception\InternalServerErrorException;
+use Baka\Http\Exception\NotFoundException;
+use Baka\Http\Exception\SessionNotFound;
+use Baka\Http\Exception\UnauthorizedException;
+use PhalconUnitTestCase;
+
+class PhalconExceptionTestTest extends PhalconUnitTestCase
+{
+    public function testSessionDoesNotExist()
+    {
+        try {
+            throw new SessionNotFound('Session not found');
+        } catch (SessionNotFound $e) {
+            $this->assertTrue($e->getHttpCode() === 499);
+        }
+
+        try {
+            throw new BadRequestException('Session not found');
+        } catch (BadRequestException $e) {
+            $this->assertTrue($e->getHttpCode() === 400);
+        }
+
+        try {
+            throw new ForbiddenException('Session not found');
+        } catch (ForbiddenException $e) {
+            $this->assertTrue($e->getHttpCode() === 403);
+        }
+
+        try {
+            throw new InternalServerErrorException('Session not found');
+        } catch (InternalServerErrorException $e) {
+            $this->assertTrue($e->getHttpCode() === 500);
+        }
+
+        try {
+            throw new NotFoundException('Session not found');
+        } catch (NotFoundException $e) {
+            $this->assertTrue($e->getHttpCode() === 404);
+        }
+
+        try {
+            throw new UnauthorizedException('Session not found');
+        } catch (UnauthorizedException $e) {
+            $this->assertTrue($e->getHttpCode() === 401);
+        }
+    }
+}


### PR DESCRIPTION
We need to provide the frontend with a specific HTTP code (499), so when they see it, they understand that the user session sent to the API doesn't exist in the DB, therefore you have to logout the user from the frontend app 

PS: This code doesn't exist in the HTTP standard code 